### PR TITLE
fix(models): add `queuedDL` state in Torrent model

### DIFF
--- a/models/src/commonMain/kotlin/Torrent.kt
+++ b/models/src/commonMain/kotlin/Torrent.kt
@@ -172,6 +172,9 @@ data class Torrent(
 
         @SerialName("forcedDL")
         FORCED_DL,
+        
+        @SerialName("queuedDL")
+        QUEUED_DL,
 
         @SerialName("checkingResumeData")
         CHECKING_RESUME_DATA,


### PR DESCRIPTION
Fixes `kotlinx.serialization.SerializationException: qbittorrent.models.Torrent.State does not contain element with name 'queuedDL'`

Closes https://github.com/DrewCarlson/qBittorrent-Kotlin/issues/21#issuecomment-1242673266