### PR TITLE
fix(models): add `queuedDL` state in Torrent model

### DIFF
--- a/models/api/qbittorrent-models.api
+++ b/models/api/qbittorrent-models.api
@@ -546,6 +546,7 @@ public final class qbittorrent/models/Torrent$State : java/lang/Enum {
 	public static final field MOVING Lqbittorrent/models/Torrent$State;
 	public static final field PAUSED_DL Lqbittorrent/models/Torrent$State;
 	public static final field PAUSED_UP Lqbittorrent/models/Torrent$State;
+	public static final field QUEUED_DL Lqbittorrent/models/Torrent$State;
 	public static final field QUEUED_UP Lqbittorrent/models/Torrent$State;
 	public static final field STALLED_DL Lqbittorrent/models/Torrent$State;
 	public static final field STALLED_UP Lqbittorrent/models/Torrent$State;

--- a/models/src/commonMain/kotlin/Torrent.kt
+++ b/models/src/commonMain/kotlin/Torrent.kt
@@ -173,6 +173,9 @@ data class Torrent(
         @SerialName("forcedDL")
         FORCED_DL,
 
+        @SerialName("queuedDL")
+        QUEUED_DL,
+
         @SerialName("checkingResumeData")
         CHECKING_RESUME_DATA,
 


### PR DESCRIPTION
Fixes `kotlinx.serialization.SerializationException: qbittorrent.models.Torrent.State does not contain element with name 'queuedDL'`