### PR TITLE
feat: add other transfer methods to client

### DIFF
--- a/client/api/qbittorrent-client.api
+++ b/client/api/qbittorrent-client.api
@@ -25,7 +25,9 @@ public final class qbittorrent/QBittorrentClient {
 	public final fun getBuildInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCategories (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getDefaultSavePath (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGlobalDownloadLimit (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getGlobalTransferInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getGlobalUploadLimit (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getLogs (ZZZZILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getLogs$default (Lqbittorrent/QBittorrentClient;ZZZZILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getPeerLogs (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -33,6 +35,7 @@ public final class qbittorrent/QBittorrentClient {
 	public final fun getPieceHashes (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPieceStates (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPreferences (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getSpeedLimitsMode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTags (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTorrentDownloadLimit (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getTorrentDownloadLimit$default (Lqbittorrent/QBittorrentClient;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -78,6 +81,8 @@ public final class qbittorrent/QBittorrentClient {
 	public final fun setFilePriority (Ljava/lang/String;Ljava/util/List;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setForceStart (Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun setForceStart$default (Lqbittorrent/QBittorrentClient;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setGlobalDownloadLimit (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setGlobalUploadLimit (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setPreferences (Lkotlinx/serialization/json/JsonObject;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setSuperSeeding (Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun setSuperSeeding$default (Lqbittorrent/QBittorrentClient;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -97,6 +102,7 @@ public final class qbittorrent/QBittorrentClient {
 	public static synthetic fun toggleFirstLastPriority$default (Lqbittorrent/QBittorrentClient;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun toggleSequentialDownload (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun toggleSequentialDownload$default (Lqbittorrent/QBittorrentClient;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun toggleSpeedLimitsMode (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class qbittorrent/QBittorrentClient$Companion {

--- a/client/src/commonMain/kotlin/QBittorrentClient.kt
+++ b/client/src/commonMain/kotlin/QBittorrentClient.kt
@@ -838,6 +838,49 @@ class QBittorrentClient(
             parameter("peers", peers.joinToString("|"))
         }.orThrow()
     }
+
+    /** The response is 1 if alternative speed limits are enabled, 0 otherwise. */
+    @Throws(QBittorrentException::class, CancellationException::class)
+    suspend fun getSpeedLimitsMode(): Int {
+        return http.get("${config.baseUrl}/api/v2/transfer/speedLimitsMode").bodyOrThrow()
+    }
+
+    @Throws(QBittorrentException::class, CancellationException::class)
+    suspend fun toggleSpeedLimitsMode() {
+        http.get("${config.baseUrl}/api/v2/transfer/toggleSpeedLimitsMode").orThrow()
+    }
+
+    /**
+     * The response is the value of current global download speed limit in bytes/second;
+     * this value will be zero if no limit is applied.
+     * */
+    @Throws(QBittorrentException::class, CancellationException::class)
+    suspend fun getGlobalDownloadLimit(): Int {
+        return http.get("${config.baseUrl}/api/v2/transfer/downloadLimit").bodyOrThrow()
+    }
+
+    @Throws(QBittorrentException::class, CancellationException::class)
+    suspend fun setGlobalDownloadLimit(limit: Int) {
+        http.get("${config.baseUrl}/api/v2/transfer/setDownloadLimit") {
+            parameter("limit", limit)
+        }.orThrow()
+    }
+
+    /**
+     * The response is the value of current global upload speed limit in bytes/second;
+     * this value will be zero if no limit is applied.
+     */
+    @Throws(QBittorrentException::class, CancellationException::class)
+    suspend fun getGlobalUploadLimit(): Int {
+        return http.get("${config.baseUrl}/api/v2/transfer/uploadLimit").bodyOrThrow()
+    }
+
+    @Throws(QBittorrentException::class, CancellationException::class)
+    suspend fun setGlobalUploadLimit(limit: Int) {
+        http.get("${config.baseUrl}/api/v2/transfer/setUploadLimit") {
+            parameter("limit", limit)
+        }.orThrow()
+    }
 }
 
 internal suspend fun login(http: HttpClient, config: QBittorrentClient.Config): HttpResponse {


### PR DESCRIPTION
Added some missing transfer methods to `QbittorrentClient` from [WebUI API](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)).

- [Get alternative speed limits state](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-alternative-speed-limits-state)
- [Toggle alternative speed limits](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#toggle-alternative-speed-limits)
- [Get global download limit](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-global-download-limit)
- [Set global download limit](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-global-download-limit)
- [Get global upload limit](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#get-global-upload-limit)
- [Set global upload limit](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-global-upload-limit)
