### PR TITLE
Support torrent deletion in qBittorrent 4.5.0

### DIFF
--- a/client/src/commonMain/kotlin/QBittorrentClient.kt
+++ b/client/src/commonMain/kotlin/QBittorrentClient.kt
@@ -399,10 +399,13 @@ class QBittorrentClient(
         hashes: List<String>,
         deleteFiles: Boolean = false
     ) {
-        http.get("${config.baseUrl}/api/v2/torrents/delete") {
-            parameter("hashes", hashes.joinToString("|"))
-            parameter("deleteFiles", deleteFiles)
-        }.orThrow()
+        http.submitForm(
+            "${config.baseUrl}/api/v2/torrents/delete",
+            formParameters = Parameters.build {
+                append("hashes", hashes.joinToString("|"))
+                append("deleteFiles", deleteFiles.toString())
+            }
+        ).orThrow()
     }
 
     /**


### PR DESCRIPTION
Hey,
seems that torrent deletion using the GET request does not work anymore on version 4.5.0, I don't see any changelog that explicitly states that though, nor there is any API update, but their documentation states that any state-changing operation should be done using POST requests. Seems that Python's qbittorent-api has already [moved to POST request](https://github.com/rmartin16/qbittorrent-api/blob/1c2c0ddf41d25cb3953247461567c9a501a85788/qbittorrentapi/torrents.py#L1761) as well.
I've tested it against qbittorrent 4.5.0 and it started working for me. Documentation suggests that the API should be able accept POST requests even for older 4.1+ versions but I haven't checked.